### PR TITLE
Update common-interfaces.ts

### DIFF
--- a/src/model/common-interfaces.ts
+++ b/src/model/common-interfaces.ts
@@ -36,7 +36,7 @@ export interface NgcLayouts {
  * Interface representing the cookie consent status.
  */
 export interface NgcCookieConsentStatus {
-  [key: string]: 'deny' | 'allow' | 'dismiss';
+  [key: string]: 'deny' | 'allow' | 'dismiss' | undefined;
   allow?: 'allow';
   deny?: 'deny';
   dismiss?: 'dismiss';


### PR DESCRIPTION
See issue #11.
Optional interface elements are blocking TypeScript compilation, string or undefined is not assignable to string index type string.