### PR TITLE
fix: cookieconsent may be undefined

### DIFF
--- a/src/service/cookieconsent.service.ts
+++ b/src/service/cookieconsent.service.ts
@@ -131,7 +131,7 @@ export class NgcCookieConsentService {
    */
   init(config: NgcCookieConsentConfig): void {
 
-    if (this.window) { // For Angular Universal suport
+    if (this.window && this.window.cookieconsent) { // For Angular Universal suport
       this.cookieconsent = this.window.cookieconsent;
 
       this.config = config;


### PR DESCRIPTION
We get errors on Sentry for older Browsers:

```
undefined is not an object (evaluating 'this.cookieconsent.initialise')
```

This is just a quickfix for it, but still better than breaking the app!