### PR TITLE
fix: add missing generic type to angular module

### DIFF
--- a/src/cookieconsent.module.ts
+++ b/src/cookieconsent.module.ts
@@ -12,7 +12,7 @@ import { WindowService, NgcCookieConsentConfig, NgcCookieConsentService } from '
 })
 export class NgcCookieConsentModule {
 
-  static forRoot(config: NgcCookieConsentConfig): ModuleWithProviders {
+  static forRoot(config: NgcCookieConsentConfig): ModuleWithProviders<NgcCookieConsentModule> {
     return {
       ngModule: NgcCookieConsentModule,
       providers: [WindowService, { provide: NgcCookieConsentConfig, useValue: config }, NgcCookieConsentService]


### PR DESCRIPTION
This PR will make ngx-cookieconsent compatible with angular 10