### PR TITLE
feat(core): add `initialized$` and `initializationError$` subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ export class AppComponent implements OnInit, OnDestroy {
   private popupOpenSubscription: Subscription;
   private popupCloseSubscription: Subscription;
   private initializeSubscription: Subscription;
+  private initializedSubscription!: Subscription;
+  private initializationErrorSubscription!: Subscription;
   private statusChangeSubscription: Subscription;
   private revokeChoiceSubscription: Subscription;
   private noCookieLawSubscription: Subscription;
@@ -166,7 +168,21 @@ export class AppComponent implements OnInit, OnDestroy {
 
     this.initializeSubscription = this.ccService.initialize$.subscribe(
       (event: NgcInitializeEvent) => {
-        // you can use this.ccService.getConfig() to do stuff...
+        // the cookieconsent is initilializing... Not yet safe to call methods like `NgcCookieConsentService.hasAnswered()`
+        console.log(`initialize: ${JSON.stringify(event)}`);
+      });
+    
+    this.initializedSubscription = this.ccService.initialized$.subscribe(
+      () => {
+        // the cookieconsent has been successfully initialized.
+        // It's now safe to use methods on NgcCookieConsentService that require it, like `hasAnswered()` for eg...
+        console.log(`initialized: ${JSON.stringify(event)}`);
+      });
+
+    this.initializationErrorSubscription = this.ccService.initializationError$.subscribe(
+      (event: NgcInitializationErrorEvent) => {
+        // the cookieconsent has failed to initialize... 
+        console.log(`initializationError: ${JSON.stringify(event.error?.message)}`);
       });
 
     this.statusChangeSubscription = this.ccService.statusChange$.subscribe(

--- a/apps/ngx-cookieconsent-demo/src/app/app.component.ts
+++ b/apps/ngx-cookieconsent-demo/src/app/app.component.ts
@@ -2,12 +2,11 @@ import { Component, OnInit, OnDestroy, Inject, PLATFORM_ID } from '@angular/core
 import { Router, NavigationEnd, Event } from '@angular/router';
 import { isPlatformBrowser } from '@angular/common';
 
-import { NgcCookieConsentService, NgcInitializeEvent, NgcStatusChangeEvent, NgcNoCookieLawEvent } from 'ngx-cookieconsent';
+import { NgcCookieConsentService, NgcInitializeEvent, NgcInitializationErrorEvent, NgcStatusChangeEvent, NgcNoCookieLawEvent } from 'ngx-cookieconsent';
 
 import { filter } from 'rxjs/operators';
 import { Subscription } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
-
 @Component({
   selector: 'ngc-demo-root',
   templateUrl: './app.component.html',
@@ -19,6 +18,8 @@ export class AppComponent implements OnInit, OnDestroy{
   private popupOpenSubscription!: Subscription;
   private popupCloseSubscription!: Subscription;
   private initializeSubscription!: Subscription;
+  private initializedSubscription!: Subscription;
+  private initializationErrorSubscription!: Subscription;
   private statusChangeSubscription!: Subscription;
   private revokeChoiceSubscription!: Subscription;
   private noCookieLawSubscription!: Subscription;
@@ -49,8 +50,21 @@ export class AppComponent implements OnInit, OnDestroy{
 
     this.initializeSubscription = this.ccService.initialize$.subscribe(
       (event: NgcInitializeEvent) => {
-        // you can use this.ccService.getConfig() to do stuff...
+        // the cookieconsent is initilializing... Not yet safe to call methods like `NgcCookieConsentService.hasAnswered()`
         console.log(`initialize: ${JSON.stringify(event)}`);
+      });
+    
+    this.initializedSubscription = this.ccService.initialized$.subscribe(
+      () => {
+        // the cookieconsent has been successfully initialized.
+        // It's now safe to use methods on NgcCookieConsentService that require it, like `hasAnswered()` for eg...
+        console.log(`initialized: ${JSON.stringify(event)}`);
+      });
+
+    this.initializationErrorSubscription = this.ccService.initializationError$.subscribe(
+      (event: NgcInitializationErrorEvent) => {
+        // the cookieconsent has failed to initialize... 
+        console.log(`initializationError: ${JSON.stringify(event.error?.message)}`);
       });
 
     this.statusChangeSubscription = this.ccService.statusChange$.subscribe(

--- a/libs/ngx-cookieconsent/src/index.ts
+++ b/libs/ngx-cookieconsent/src/index.ts
@@ -11,4 +11,4 @@ export {
     NgcCookiePosition, NgcCookieLayout, NgcCookieType, NgcCookieTheme, NgcCookieCompliance, NgcCookieOptions
 } from './lib/model/index';
 
-export { NgcInitializeEvent, NgcStatusChangeEvent, NgcNoCookieLawEvent } from './lib/event/index';
+export { NgcInitializeEvent, NgcInitializationErrorEvent, NgcStatusChangeEvent, NgcNoCookieLawEvent } from './lib/event/index';

--- a/libs/ngx-cookieconsent/src/lib/event/index.ts
+++ b/libs/ngx-cookieconsent/src/lib/event/index.ts
@@ -1,4 +1,5 @@
 export * from './status-change.event';
 export * from './initialize.event';
+export * from './initialization-error.event';
 export * from './no-cookie-law.event';
 

--- a/libs/ngx-cookieconsent/src/lib/event/initialization-error.event.ts
+++ b/libs/ngx-cookieconsent/src/lib/event/initialization-error.event.ts
@@ -1,0 +1,10 @@
+
+/**
+ * Event fired when an error occured during Cookie Consent initialization.
+ */
+export interface NgcInitializationErrorEvent {
+  /**
+   * The error that occured during initialization.
+   */
+  error: Error;
+}

--- a/libs/ngx-cookieconsent/src/lib/service/cookieconsent-config.ts
+++ b/libs/ngx-cookieconsent/src/lib/service/cookieconsent-config.ts
@@ -204,11 +204,32 @@ export class NgcCookieConsentConfig {
   ignoreClicksFrom?: string[];
 
   // these callback hooks are called at certain points in the program execution
+  
+  /**
+   * This is called when the popup is opened. It can be used to trigger an animation, or to attach extra handlers, etc.
+   */
   onPopupOpen?: () => void;
+
+  /**
+   * This is called when the popup is closed. It can be used to clean up commands from onPopupOpen.
+   */
   onPopupClose?: () => void;
+
+  /**
+   * This is called on start up, with the current chosen compliance. It can be used to tell you if the user has already consented or not as soon as you initialise the tool.
+   */
   onInitialise?: (status: 'allow' | 'deny' | 'dismiss') => void;
+
+  /**
+   * This is called any time the status is changed. This can be used to react to changes that are made to the compliance level. You can use the popup instance functions from within these callbacks too. I.E. `this.hasAnswered()` and `this.hasConsented()`.
+   */
   onStatusChange?: (status: 'allow' | 'deny' | 'dismiss', chosenBefore: boolean) => void;
+
+  /**
+   * This is called when the user clicks the `revoke` button. This means that their current choice has been invalidated.
+   */
   onRevokeChoice?: () => void;
+  
   onNoCookieLaw?: (countryCode: string, country: string) => void;
 
 }


### PR DESCRIPTION
These events can be subscribed to in order to be notified when:
*  the `cookieconsent` library **has been successfully initialized**
*  the `cookieconsent` library **failed to initialize** due to an error